### PR TITLE
Adds ".DS_Store" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 # Temporary files created by R markdown
 *.utf8.md
 *.knit.md
+
+# MacOS specific .DS_Store files
+.DS_Store


### PR DESCRIPTION
.DS_Store is a MacOS specific file storing certain settings for
Finder (MacOS native file explorer). These can often cause merge
conflicts when two MacOS users collaborate on a Git project and
are not part of the content of the repo anyways.